### PR TITLE
Fixes File instance

### DIFF
--- a/Spec/FileFactory.php
+++ b/Spec/FileFactory.php
@@ -9,7 +9,7 @@
 namespace Giftcards\FixedWidth\Spec;
 
 
-use Giftcards\FixedWidth\File;
+use Giftcards\FixedWidth\FileInterface;
 use Giftcards\FixedWidth\FileBuilder;
 use Giftcards\FixedWidth\FileFactory as BaseFileFactory;
 use Giftcards\FixedWidth\FileReader;
@@ -51,7 +51,7 @@ class FileFactory extends BaseFileFactory
         return new FileBuilder($name, $this->specLoader->loadSpec($specName), $this->formatter);
     }
 
-    public function createReader(File $file, $specName)
+    public function createReader(FileInterface $file, $specName)
     {
         return new FileReader(
             $file,


### PR DESCRIPTION
FileFactory was preventing instantiation of FileReader by requiring a File instance, instead of a FileInterface.
